### PR TITLE
iter_files: fix lifetime of returned iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use {
 ///
 /// The iterator checks if the header of an entry is correct. If it is corrupt (e.g., wrong magic
 /// value), the iterator stops iterating.
-pub fn iter_files(cpio_binary: &[u8]) -> impl Iterator<Item = Entry<'_>> {
+pub fn iter_files<'a>(cpio_binary: &'a [u8]) -> impl Iterator<Item = Entry<'a>> {
     Iter::new(cpio_binary)
 }
 


### PR DESCRIPTION
The `Entry` lives long as the data lives :)

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>